### PR TITLE
Add LRU cache with background refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "eslint . && npm run build"
   },
   "author": "Sumeet Adur",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.9.1",
@@ -36,6 +36,7 @@
     "cssnano": "^3.5.2",
     "d3-time-format": "^2.0.0",
     "debowerify": "^1.4.1",
+    "debug": "^2.2.0",
     "del-cli": "^0.2.0",
     "dotenv": "^2.0.0",
     "eslint": "^2.7.0",
@@ -62,6 +63,7 @@
     "koa-router": "^7.0.1",
     "koa-static": "^3.0.0",
     "lodash": "^4.11.1",
+    "lru-cache": "^4.0.1",
     "marked": "^0.3.5",
     "next-ft-api-client": "^3.25.1",
     "pug": "^2.0.0-beta4",

--- a/src/server/lib/cache.js
+++ b/src/server/lib/cache.js
@@ -1,0 +1,78 @@
+import lruCache from 'lru-cache';
+import debugLogger from 'debug';
+
+const debug = debugLogger('cache');
+const pending = new Map();
+const noop = () => {};
+const maxAge = 60 * 1000 * 5; // 5 mins
+
+const lru = lruCache({
+  maxAge,
+  max: 200000, // 200K (ish)
+  stale: true,
+  length: (n, key) => JSON.stringify(n).length + JSON.stringify(key).length,
+});
+
+export default function cache(keyFn = noop, refresh = noop, max = maxAge) {
+  const key = typeof keyFn === 'string' ? keyFn : keyFn();
+
+  // key can be falsey to bypass caching. e.g.
+  // const keyFn = () => {
+  //    return !bypassCache && 'my-key';
+  // }
+  if (!key) return refresh();
+
+  // grab the current value in case the key is
+  // just about to be deleted so we can serve
+  // stale in the event of a refresh error
+  let stale = lru.peek(key);
+
+  const isCached = lru.has(key);
+  const hasStaleValue = !!stale;
+
+  function doRefresh() {
+    debug('refreshing %s', key);
+    return refresh()
+      .then(result => {
+        debug('caching value %s', key);
+        lru.set(key, result, max);
+        pending.delete(key);
+        return result;
+      })
+      .catch(err => {
+        pending.delete(key);
+
+        if (!hasStaleValue) {
+          throw err;
+        }
+
+        // swallow the error and serve stale
+        debug('restore previous value %s', key)
+        lru.set(key, stale, max);
+        return stale;
+      });
+  }
+
+  if (isCached) {
+    debug('cache hit %s', key);
+    return Promise.resolve(lru.get(key));
+  } else if (pending.has(key)) {
+    debug('already pending %s', key);
+    return pending.get(key);
+  } else if (hasStaleValue) {
+    debug('return stale and schedule bg refresh %s', key);
+    const p = Promise.resolve(stale);
+    pending.set(key, p);
+    process.nextTick(() => {
+      doRefresh().catch(err => {
+        console.error('Failed background refresh', err.message);
+      });
+    });
+    return p;
+  }
+
+  const pendingPromise = doRefresh();
+  pending.set(key, pendingPromise);
+  return pendingPromise;
+
+}

--- a/src/server/lib/resolve-id.js
+++ b/src/server/lib/resolve-id.js
@@ -6,6 +6,7 @@ const vanities = {
 		world: 'MQ&#x3D;&#x3D;-U2VjdGlvbnM&#x3D;',
 		'chart-doctor': 'YTIwMWFhZGEtOGE4MS00ZDdlLTlhYjUtZjA4NmY0ZjcxNzhh-QnJhbmRz',
 		'the-big-read': 'MTE4-U2VjdGlvbnM&#x3D;',
+		'ft-data': 'MGY2ZTQ3MTYtYjJiNS00ODVhLTlkYTktNzZlNzc3YTcxOWYy-QnJhbmRz',
 	},
 
 	list: {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -63,7 +63,7 @@ async function render(ctx, next) {
 	await next();
 	ctx.set('Cache-Control', 'public, maxage=1200');
 	ctx.set('Server', 'ig-onwardjourney');
-		if (ctx.params.format === 'html') {
+	if (ctx.params.format === 'html') {
 		if (ctx.list.items.length) {
 			ctx.render(ctx.params.layout || 'default', ctx.list);
 		}

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -61,7 +61,7 @@ async function limit(ctx, next) {
 
 async function render(ctx, next) {
 	await next();
-	ctx.set('Cache-Control', 'public, maxage=1200');
+	ctx.set('Cache-Control', 'public, max-age=1200');
 	ctx.set('Server', 'ig-onwardjourney');
 	if (ctx.params.format === 'html') {
 		if (ctx.list.items.length) {


### PR DESCRIPTION
This caches list models (content from CAPI, List API and ES) to expire in LRU
order.

We cache the **models** before rendering them. **HTML** strings are _not_
cached at the moment because they’ll probably be many variants of the view,
depending on the query params leading to a fragmented cache. Instead, the CDN is used to cache HTML at the moment.

The background refresh bit: if the cache contains an expired key then
we serve the expired/stale value while we get an updated value in the
background. If that update fails the we restore the value in the LRU
cache.

Also we ensure only one update happen at time for a given key. This is
to prevent the same request happening over and over while a stale key
is present.

Overall this change should make the Onward Journey service quicker and
more resilient to upstream timeouts/outages/errors.