### PR TITLE
🐛 Fixes issues caused by depreciation of old ES API

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Sumeet Adur",
   "license": "MIT",
   "dependencies": {
+    "@financial-times/n-es-client": "^1.0.0-beta.6",
     "autoprefixer": "^6.3.6",
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.2",
@@ -65,7 +66,6 @@
     "lodash": "^4.11.1",
     "lru-cache": "^4.0.1",
     "marked": "^0.3.5",
-    "next-ft-api-client": "^3.26.0",
     "pug": "^2.0.0-beta4",
     "trip": "^1.0.3"
   },

--- a/src/server/lib/load-list.js
+++ b/src/server/lib/load-list.js
@@ -1,7 +1,42 @@
 import 'isomorphic-fetch';
 import createError from 'http-errors';
-import api from 'next-ft-api-client';
+import api from '@financial-times/n-es-client';
 import list from '../models/list';
+
+function getList(opts) {
+	const uuid = opts.uuid;
+	return fetch(`https://api.ft.com/lists/${uuid}?apiKey=${process.env.API_KEY}`) // Is there a better way of doing this?
+		.then(res => res.json())
+		.catch(() => {
+			throw new createError.NotFound();
+		});
+}
+
+function getItems(opts) {
+	const uuid = [].concat(opts.uuid);
+	const returnMany = Array.isArray(opts.uuid);
+
+	if (uuid.length === 0) {
+		return Promise.resolve([]);
+	}
+
+	return api.mget({
+		ids: uuid,
+	})
+	.then((docs) => {
+		if (returnMany) {
+			return docs;
+		}
+		if (docs.length === 0) {
+			throw new createError.NotFound();
+		}
+
+		return docs[0];
+	})
+	.catch(() => {
+		throw new createError.NotFound();
+	});
+}
 
 /**
  * Downloads a list of articles from CAPI and returns the UUIDs, plus any metadata.
@@ -9,10 +44,9 @@ import list from '../models/list';
 export default async function loadList(id) {
 	let apiResult;
 	try {
-		apiResult = await api.lists({ uuid: id, retry: 6 });
+		apiResult = await getList({ uuid: id, retry: 6 });
 	}
 	catch (err) {
-
 		if (err.name === 'BadServerResponseError') {
 			throw new createError.NotFound();
 		}
@@ -37,7 +71,7 @@ export default async function loadList(id) {
 	return list({
 		id,
 		type: 'list',
-		items: await api.content({ uuid: uuids, index: 'v3_api_v2' }),
+		items: await getItems({ uuid: uuids, index: 'v3_api_v2' }),
 		title: apiResult.title,
 		layoutHint: apiResult.layoutHint,
 	});

--- a/src/server/lib/load-thing.js
+++ b/src/server/lib/load-thing.js
@@ -1,7 +1,71 @@
 import 'isomorphic-fetch';
 import createError from 'http-errors';
-import api from 'next-ft-api-client';
+import api from '@financial-times/n-es-client';
 import list from '../models/list';
+
+function compat(tag) {
+	return {
+		term: Object.assign({}, { name: tag.prefLabel, id: tag.idV1 }, tag),
+	};
+}
+
+function getTag(id, type) {
+	const data = {
+		_source: ['metadata'],
+		query: {
+			term: {},
+		},
+		sort: {
+			publishedDate: {
+				order: 'desc',
+			},
+		},
+		size: 1,
+	};
+	data.query.term[`metadata.${type}`] = id;
+	return api.search(data)
+	.then(([resultData]) => {
+		const { metadata } = resultData;
+		if (metadata) {
+			return {
+				status: 200,
+				body: compat(metadata.find(tag => tag[type] === id)),
+			};
+		}
+		return {
+			status: 404,
+			body: { error: 'Not found, could be deleted or might never had existed' },
+		};
+	})
+	.catch(() => ({
+		status: 500,
+		body: { error: 'Server error' },
+	}));
+}
+
+function getThings(opts) {
+	const identifierValues = opts.identifierValues;
+	const identifierType = opts.identifierType || 'idV1';
+
+	if (identifierValues.length === 0 || !Array.isArray(identifierValues)) {
+		return Promise.resolve([]);
+	}
+
+	return Promise.all(
+		identifierValues.map(id => getTag(id, identifierType))
+	).then(results => {
+		const items = results
+					.filter(r => r.status === 200)
+					.map(r => r.body.term);
+		return {
+			total: items.length,
+			items,
+		};
+	})
+	.catch(() => {
+		throw new createError.NotFound();
+	});
+}
 
 /**
  * Downloads a list of articles from CAPI and returns
@@ -9,15 +73,17 @@ import list from '../models/list';
  */
 export default function loadThing(id) {
 	return Promise.all([
-		api.search({ filter: {
-			bool: {
-				must: [
-					{ term: { 'metadata.idV1': id } },
-				],
+		api.search({
+			query: {
+				bool: {
+					filter: [
+						{ term: { 'metadata.idV1': id } },
+					],
+				},
 			},
-		} }),
+		}),
 
-		api.things({ identifierValues: [id] }),
+		getThings({ identifierValues: [id] }),
 
 	]).then(([searchResults, tags]) => {
 		if (!tags.items || !tags.items.length) {
@@ -36,7 +102,6 @@ export default function loadThing(id) {
 		// workaround api client rejecting with a stackless error
 		// - see https://github.com/matthew-andrews/fetchres/issues/9
 		if ((!err instanceof Error) || !err.stack) {
-
 			if (err.name === 'BadServerResponseError') {
 				throw new createError.NotFound();
 			}


### PR DESCRIPTION
I've removed `next-ft-api-client` and replaced it with @financial-times/n-es-client, updating any old ES query code to 5.x.

It's possible I've duplicated some code [here](https://github.com/ft-interactive/onwardjourney/compare/remove-next-ft-api-client?expand=1#diff-6b3b2dfaf19dd9cd0aebbdf5b2c36b9dR12); for some reason I wasn't able to get n-es-client's `tag` method to return properly.